### PR TITLE
[sec/2sv] Require 2SV for all admin users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -201,3 +201,5 @@ Naming/MethodParameterName:
 Layout/LineLength:
   Exclude:
     - features/**/*_steps.rb
+Metrics/AbcSize:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem "lockbox" # Game key encryption
 gem "monetize"
 gem "money-rails", "~>1.12"
 gem "rollbar"
+gem "rotp"
+gem "rqrcode"
 gem "sidekiq"
 gem "stripe"
 gem "watir"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    chunky_png (1.4.0)
     climate_control (1.0.0)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
@@ -333,6 +334,11 @@ GEM
       railties (>= 5.0)
     rexml (3.2.4)
     rollbar (3.1.2)
+    rotp (6.2.0)
+    rqrcode (1.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 0.2)
+    rqrcode_core (0.2.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -469,6 +475,8 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3)
   rollbar
+  rotp
+  rqrcode
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/controllers/admin/otp_controller.rb
+++ b/app/controllers/admin/otp_controller.rb
@@ -1,0 +1,47 @@
+class Admin::OTPController < ApplicationController
+  before_action :require_setup, only: %i[input]
+  before_action :prevent_double_setup, only: %i[setup]
+  before_action :require_otp_issuer
+
+  def input; end
+
+  def setup
+    session[:otp_secret] = ROTP::Base32.random
+    totp = ROTP::TOTP.new(session[:otp_secret], issuer: ENV["OTP_ISSUER"])
+    @otp_url = totp.provisioning_uri(current_admin_user.email)
+    @qr_code = RQRCode::QRCode.new(@otp_url).as_svg(standalone: false, module_size: 5)
+  end
+
+  def verify
+    otp_secret = current_admin_user.otp_secret || session[:otp_secret]
+    raise "Missing OTP secret" if otp_secret.blank?
+
+    totp = ROTP::TOTP.new(otp_secret, issuer: ENV["OTP_ISSUER"], after: current_admin_user.last_otp_at)
+
+    if totp.verify(params[:otp_code], drift_behind: 3)
+      current_admin_user.otp_secret ||= session[:otp_secret]
+      current_admin_user.update(last_otp_at: (session[:last_otp_at] = Time.zone.now))
+      session[:otp_secret] = nil
+
+      redirect_to admin_root_path
+    elsif current_admin_user.has_2sv?
+      redirect_to admin_otp_input_path
+    else
+      redirect_to admin_otp_setup_path
+    end
+  end
+
+private
+
+  def require_setup
+    redirect_to admin_otp_setup_path unless current_admin_user&.has_2sv?
+  end
+
+  def prevent_double_setup
+    redirect_to admin_otp_input_path if current_admin_user&.has_2sv?
+  end
+
+  def require_otp_issuer
+    raise "Missing OTP issuer" if ENV["OTP_ISSUER"].blank?
+  end
+end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,0 +1,3 @@
+class Admin::SessionsController < ActiveAdmin::Devise::SessionsController
+  skip_before_action :enforce_2sv
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,4 +18,8 @@ private
     Rails.logger.error(message)
     render json: { errors: [message] }, status: :unprocessable_entity
   end
+
+  def enforce_2sv
+    redirect_to admin_otp_input_path unless session[:last_otp_at]
+  end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -9,6 +9,8 @@
 # **`id`**                      | `bigint`           | `not null, primary key`
 # **`email`**                   | `string`           | `default(""), not null`
 # **`encrypted_password`**      | `string`           | `default(""), not null`
+# **`last_otp_at`**             | `datetime`         |
+# **`otp_secret`**              | `string`           |
 # **`remember_created_at`**     | `datetime`         |
 # **`reset_password_sent_at`**  | `datetime`         |
 # **`reset_password_token`**    | `string`           |
@@ -23,5 +25,9 @@ class AdminUser < ApplicationRecord
 
   def email_address
     email
+  end
+
+  def has_2sv?
+    otp_secret.present?
   end
 end

--- a/app/views/admin/otp/_input_form.html.erb
+++ b/app/views/admin/otp/_input_form.html.erb
@@ -1,0 +1,6 @@
+<h3>Enter a code from your authenticator</h3>
+
+<%= form_tag admin_otp_verify_path do %>
+  <%= text_field_tag :otp_code, {}, placeholder: "112233" %>
+  <button>Verify</button>
+<% end %>

--- a/app/views/admin/otp/input.html.erb
+++ b/app/views/admin/otp/input.html.erb
@@ -1,0 +1,3 @@
+<h2>2SV verification</h2>
+
+<%= render "admin/otp/input_form" %>

--- a/app/views/admin/otp/setup.html.erb
+++ b/app/views/admin/otp/setup.html.erb
@@ -1,0 +1,7 @@
+<h2>Set up 2SV</h2>
+
+<svg width="400" height="400">
+  <%= @qr_code.html_safe %>
+</svg>
+
+<%= render "admin/otp/input_form" %>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -150,7 +150,7 @@ ActiveAdmin.setup do |config|
   # You can add before, after and around filters to all of your
   # Active Admin resources and pages from here.
   #
-  # config.before_action :do_something_awesome
+  config.before_action :enforce_2sv
 
   # == Attribute Filters
   #

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "OTP"
+  inflect.acronym "2SV"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,17 @@
 Rails.application.routes.draw do
-  devise_for :admin_users, ActiveAdmin::Devise.config
+  devise_config = ActiveAdmin::Devise.config
+  devise_config[:controllers][:sessions] = "admin/sessions"
+
+  devise_for :admin_users, devise_config
+
   ActiveAdmin.routes(self)
+
+  namespace :admin do
+    get "/2sv/setup", to: "otp#setup", as: "otp_setup"
+    get "/2sv/verify", to: "otp#input", as: "otp_input"
+    post "/2sv/verify", to: "otp#verify", as: "otp_verify"
+  end
+
   resources :donations, except: %i[edit update delete destroy]
   resources :keys, only: [:index]
   resources :games, only: [:show]

--- a/db/migrate/20210325113403_add_otp_to_admin_user.rb
+++ b/db/migrate/20210325113403_add_otp_to_admin_user.rb
@@ -1,0 +1,6 @@
+class AddOtpToAdminUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :admin_users, :otp_secret, :string
+    add_column :admin_users, :last_otp_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_002325) do
+ActiveRecord::Schema.define(version: 2021_03_25_113403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,8 @@ ActiveRecord::Schema.define(version: 2021_03_25_002325) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "otp_secret"
+    t.datetime "last_otp_at"
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end

--- a/features/admin/2sv.feature
+++ b/features/admin/2sv.feature
@@ -1,0 +1,8 @@
+Feature: Admin: 2SV
+
+Scenario: 2SV is required for all admin users
+  Given an admin user without 2SV enabled
+  When the admin user tries to log in
+  Then they should be redirected to set up 2SV
+  When they set up 2SV
+  Then the admin should be able to log in

--- a/features/step_definitions/admin/2sv_steps.rb
+++ b/features/step_definitions/admin/2sv_steps.rb
@@ -1,0 +1,20 @@
+Given("an admin user without 2SV enabled") do
+  @admin_user = FactoryBot.create(:admin_user, :without_2sv)
+end
+
+When("the admin user tries to log in") do
+  log_in_as(@admin_user, expect_failure: true)
+end
+
+Then("they should be redirected to set up 2SV") do
+  expect(page).to have_css("h2", text: "Set up 2SV")
+end
+
+When("they set up 2SV") do
+  @admin_user.update(otp_secret: ROTP::Base32.random)
+end
+
+Then("the admin should be able to log in") do
+  complete_2sv(@admin_user.otp_secret)
+  expect(page).to have_css("h2", text: "Dashboard")
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,8 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
+ENV["OTP_ISSUER"] = "Jingle Jam (test)"
+
 require "cucumber/rails"
 
 require "webdrivers"

--- a/features/support/helpers/login_helpers.rb
+++ b/features/support/helpers/login_helpers.rb
@@ -1,14 +1,21 @@
 module LoginHelpers
-  def log_in_with(email_address, visit_page: true, expect_failure: false)
+  def log_in_with(email_address, otp_secret:, visit_page: true, expect_failure: false)
     visit "/admin/login" if visit_page
     fill_in "Email", with: email_address
     fill_in "Password", with: "password"
     click_on "Login"
 
+    complete_2sv(otp_secret) if otp_secret.present?
+
     unless expect_failure
       expect(page).to have_css("#current_user a", text: email_address)
       @current_admin_user = AdminUser.find_by(email: email_address)
     end
+  end
+
+  def complete_2sv(otp_secret)
+    fill_in "112233", with: ROTP::TOTP.new(otp_secret).at(Time.zone.now)
+    click_on "Verify"
   end
 
   def log_in_as(user_or_factory, traits: nil, **kwargs)
@@ -25,7 +32,7 @@ module LoginHelpers
     when Donator
       use_magic_link(user)
     when AdminUser
-      log_in_with(user.email, **kwargs)
+      log_in_with(user.email, otp_secret: user.otp_secret, **kwargs)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 require "spec_helper"
 
 ENV["RAILS_ENV"] ||= "test"
+ENV["OTP_ISSUER"] = "Jingle Jam (test)"
 
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production

--- a/test/factories/admin_user_factory.rb
+++ b/test/factories/admin_user_factory.rb
@@ -4,5 +4,11 @@ FactoryBot.define do
 
     password { "password" }
     password_confirmation { password }
+
+    otp_secret { ROTP::Base32.random }
+
+    trait :without_2sv do
+      otp_secret { nil }
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/SmartCasual/jingle-jam/issues/31

```
Feature: Admin: 2SV

  Scenario: 2SV is required for all admin users  # features/admin/2sv.feature:3
    Given an admin user without 2SV enabled      # features/step_definitions/admin/2sv_steps.rb:1
    When the admin user tries to log in          # features/step_definitions/admin/2sv_steps.rb:5
    Then they should be redirected to set up 2SV # features/step_definitions/admin/2sv_steps.rb:9
    When they set up 2SV                         # features/step_definitions/admin/2sv_steps.rb:13
    Then the admin should be able to log in      # features/step_definitions/admin/2sv_steps.rb:17

1 scenario (1 passed)
```