### PR TITLE
[charities] Add charity info pages

### DIFF
--- a/app/controllers/charities_controller.rb
+++ b/app/controllers/charities_controller.rb
@@ -1,0 +1,5 @@
+class CharitiesController < ApplicationController
+  def show
+    @charity = Charity.find(params[:id])
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,7 @@
 class HomeController < ApplicationController
   def home
     @bundle_definitions = BundleDefinition.order(:name)
+    @charities = Charity.order(:name)
   end
 
   def magic_redirect

--- a/app/models/charity.rb
+++ b/app/models/charity.rb
@@ -1,0 +1,17 @@
+# ## Schema Information
+#
+# Table name: `charities`
+#
+# ### Columns
+#
+# Name               | Type               | Attributes
+# ------------------ | ------------------ | ---------------------------
+# **`id`**           | `bigint`           | `not null, primary key`
+# **`description`**  | `text`             |
+# **`name`**         | `string`           | `not null`
+# **`created_at`**   | `datetime`         | `not null`
+# **`updated_at`**   | `datetime`         | `not null`
+#
+class Charity < ApplicationRecord
+  validates :name, presence: true
+end

--- a/app/views/charities/show.html.erb
+++ b/app/views/charities/show.html.erb
@@ -1,0 +1,3 @@
+<h2><%= @charity.name %></h2>
+
+<p><%= @charity.description %></p>

--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -23,3 +23,12 @@
 <p>
   <%= link_to "Donate here!", donations_path %>
 </p>
+
+<% if @charities.any? %>
+  <h2>Charities</h2>
+  <ul>
+    <% @charities.each do |charity| %>
+      <li><%= link_to charity.name, charity_path(charity) %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   resources :donations, except: %i[edit update delete destroy]
   resources :keys, only: [:index]
   resources :games, only: [:show]
+  resources :charities, only: [:show]
 
   post "/stripe/prep-checkout", to: "stripe#prep_checkout_session"
   post "/stripe/webhook", to: "stripe#webhook"

--- a/db/migrate/20210326140555_create_charity.rb
+++ b/db/migrate/20210326140555_create_charity.rb
@@ -1,0 +1,10 @@
+class CreateCharity < ActiveRecord::Migration[6.1]
+  def change
+    create_table :charities do |t|
+      t.string :name, index: true, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_113403) do
+ActiveRecord::Schema.define(version: 2021_03_26_140555) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,14 @@ ActiveRecord::Schema.define(version: 2021_03_25_113403) do
     t.bigint "bundle_definition_id", null: false
     t.index ["bundle_definition_id"], name: "index_bundles_on_bundle_definition_id"
     t.index ["donator_id"], name: "index_bundles_on_donator_id"
+  end
+
+  create_table "charities", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_charities_on_name"
   end
 
   create_table "donations", force: :cascade do |t|

--- a/features/bundles/game_info.feature
+++ b/features/bundles/game_info.feature
@@ -5,4 +5,4 @@ Scenario: Game info available from bundle description
     | Game | Description               |
     | Halo | I guess he's in the navy? |
   When a donator clicks on "Halo" in the bundle definition
-  Then they should see "Halo" and its description
+  Then they should see the game "Halo" and its description

--- a/features/charities/charity_info.feature
+++ b/features/charities/charity_info.feature
@@ -1,0 +1,8 @@
+Feature: Charities: charity info
+
+Scenario: Charity info available from homepage
+  Given the following charities:
+    | Charity       | Description            |
+    | Foster's Home | For imaginary friends. |
+  When a donator clicks on "Foster's Home" on the homepage
+  Then they should see the charity "Foster's Home" and its description

--- a/features/step_definitions/bundles/game_info_steps.rb
+++ b/features/step_definitions/bundles/game_info_steps.rb
@@ -3,7 +3,7 @@ When("a donator clicks on {string} in the bundle definition") do |game_name|
   click_on game_name
 end
 
-Then("they should see {string} and its description") do |game_name|
+Then("they should see the game {string} and its description") do |game_name|
   expect(page).to have_css("h2", text: game_name)
   expect(page).to have_text(Game.find_by!(name: game_name).description)
 end

--- a/features/step_definitions/charities/charity_info_steps.rb
+++ b/features/step_definitions/charities/charity_info_steps.rb
@@ -1,0 +1,9 @@
+When("a donator clicks on {string} on the homepage") do |charity_name|
+  go_to_homepage
+  click_on charity_name
+end
+
+Then("they should see the charity {string} and its description") do |charity_name|
+  expect(page).to have_css("h2", text: charity_name)
+  expect(page).to have_text(Charity.find_by!(name: charity_name).description)
+end

--- a/features/step_definitions/charity_steps.rb
+++ b/features/step_definitions/charity_steps.rb
@@ -1,0 +1,5 @@
+Given("the following charities:") do |table|
+  table.symbolic_hashes.each do |hash|
+    FactoryBot.create(:charity, name: hash[:charity], description: hash[:description])
+  end
+end

--- a/test/factories/charity_factory.rb
+++ b/test/factories/charity_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :charity do
+    sequence(:name) { |n| "Charity #{n}" }
+  end
+end


### PR DESCRIPTION
Closes https://github.com/SmartCasual/jingle-jam/issues/6
```
Feature: Charities: charity info

  Scenario: Charity info available from homepage                         # features/charities/charity_info.feature:3
    Given the following charities:                                       # features/step_definitions/charity_steps.rb:1
      | Charity       | Description            |
      | Foster's Home | For imaginary friends. |
    When a donator clicks on "Foster's Home" on the homepage             # features/step_definitions/charities/charity_info_steps.rb:1
    Then they should see the charity "Foster's Home" and its description # features/step_definitions/charities/charity_info_steps.rb:6

1 scenario (1 passed)
```