### PR TITLE
Bump demopass from 0.2.0 to 0.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    demopass (0.2.0)
+    demopass (0.2.1)
       rack
     devise (4.7.3)
       bcrypt (~> 3.0)


### PR DESCRIPTION
Fixes an infinite redirect bug when providing the wrong password.