### PR TITLE
[streaming/twitch] Don't embed on homepage for most tests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,4 +23,9 @@ private
     session[:last_otp_at]
     redirect_to admin_otp_input_path unless session[:last_otp_at]
   end
+
+  def twitch_embed_enabled?
+    ENV.fetch("TWITCH_EMBED_ENABLED", "true") == "true"
+  end
+  helper_method :twitch_embed_enabled?
 end

--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -2,24 +2,7 @@
 
 <h2>Twitch</h2>
 
-<div id="twitch-embed" data-channel="yogscast"></div>
-
-<% content_for :head do %>
-  <script src="https://embed.twitch.tv/embed/v1.js" charset="utf-8"></script>
-
-  <script type="text/javascript">
-    onReady(function() {
-      let id = "twitch-embed";
-      let embed = document.getElementById(id);
-
-      new Twitch.Embed(id, {
-        channel: embed.dataset.channel,
-        width: 1280,
-        height: 720,
-      });
-    });
-  </script>
-<% end %>
+<%= render "streaming/twitch", channel: "yogscast" %>
 
 <h2>Bundles</h2>
 

--- a/app/views/streaming/_twitch.html.erb
+++ b/app/views/streaming/_twitch.html.erb
@@ -1,0 +1,20 @@
+<% if twitch_embed_enabled? %>
+  <div id="twitch-embed" data-channel="<%= channel %>"></div>
+
+  <% content_for :head do %>
+    <script src="https://embed.twitch.tv/embed/v1.js" charset="utf-8"></script>
+
+    <script type="text/javascript">
+      onReady(function() {
+        let id = "twitch-embed";
+        let embed = document.getElementById(id);
+
+        new Twitch.Embed(id, {
+          channel: embed.dataset.channel,
+          width: 1280,
+          height: 720,
+        });
+      });
+    </script>
+  <% end %>
+<% end %>

--- a/features/step_definitions/streaming/twitch_steps.rb
+++ b/features/step_definitions/streaming/twitch_steps.rb
@@ -1,0 +1,7 @@
+When("the user visits the homepage") do
+  go_to_homepage
+end
+
+Then("the main Yogscast twitch should be embedded on the page") do
+  expect(page).to have_css("#twitch-embed[data-channel='yogscast'] iframe[src*='.twitch.tv']")
+end

--- a/features/streaming/twitch.feature
+++ b/features/streaming/twitch.feature
@@ -1,0 +1,6 @@
+@twitch_embed_enabled
+Feature: Streaming: twitch
+
+Scenario: Main Yogscast twitch is embedded on the homepage
+  When the user visits the homepage
+  Then the main Yogscast twitch should be embedded on the page

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,7 @@
 # files.
 
 ENV["OTP_ISSUER"] = "Jingle Jam (test)"
+ENV["TWITCH_EMBED_ENABLED"] = "false"
 
 require "cucumber/rails"
 
@@ -20,6 +21,9 @@ FactoryBot.find_definitions
 
 require "sidekiq/testing"
 Sidekiq::Testing.inline!
+
+require_relative "../../test/support/with_env"
+World(WithEnv)
 
 Capybara.configure do |config|
   config.server = :puma, { Silent: true }
@@ -41,4 +45,10 @@ After do
   ::RSpec::Mocks.verify
 ensure
   ::RSpec::Mocks.teardown
+end
+
+Around("@twitch_embed_enabled") do |_, scenario|
+  with_env("TWITCH_EMBED_ENABLED" => "true") do
+    scenario.call
+  end
 end


### PR DESCRIPTION
Use the `@twitch_embed_enabled` cucumber tag if you need twitch embeds
to render.

Fixes https://github.com/SmartCasual/jingle-jam/issues/48