### PR TITLE
Charity split

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 jobs:
   test:  # our next job, called "test"
     docker:
-      - image: cimg/ruby:2.7-browsers # this is our primary docker image, where step commands run.
+      - image: cimg/ruby:2.7.3-browsers # this is our primary docker image, where step commands run.
       - image: circleci/postgres:9.5-alpine
         environment: # add POSTGRES environment variables.
           POSTGRES_USER: circleci

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -209,3 +209,5 @@ Style/NestedModifier:
   Enabled: false
 Style/SoleNestedConditional:
   Enabled: false
+Naming/VariableNumber:
+  EnforcedStyle: snake_case

--- a/app/abilities/admin_ability.rb
+++ b/app/abilities/admin_ability.rb
@@ -31,6 +31,7 @@ private
     can :read, Bundle
     can :read, Donation
     can :read, Donator
+    can :read, ActiveAdmin::Page, name: "Donation accounting", namespace_name: "admin"
   end
 
   def allow_managing_admin_accounts

--- a/app/admin/donation_accounting.rb
+++ b/app/admin/donation_accounting.rb
@@ -1,0 +1,39 @@
+ActiveAdmin.register_page "Donation accounting" do
+  content do
+    all_charities = Charity.all
+
+    breakdown = Donation
+      .includes(charity_splits: :charity)
+      .find_each.with_object(Hash.new { |h, k| h[k] = Money.new(0) }) do |donation, hash|
+        if donation.charity_splits.any?
+          donation.charity_splits.each do |split|
+            hash[split.charity] += split.amount
+          end
+        else
+          all_charities.each do |charity|
+            hash[charity] += donation.amount / all_charities.count
+          end
+        end
+      end
+
+    table do
+      caption "Donation breakdown"
+
+      thead do
+        tr do
+          th "Charity"
+          th "Total donations"
+        end
+      end
+
+      tbody do
+        breakdown.sort_by { |c, _| c.name }.each do |charity, total_donations|
+          tr do
+            td charity.name
+            td total_donations.format
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/assets/stylesheets/donations.scss
+++ b/app/assets/stylesheets/donations.scss
@@ -1,0 +1,21 @@
+#donation-form {
+  input.amount {
+    width: 6em;
+  }
+
+  ul.charity-split {
+    list-style: none;
+    padding-left: 1em;
+    padding-top: 5px;
+    font-size: 0.8em;
+    border: 1px solid #888;
+
+    p {
+      margin: 0;
+    }
+
+    input.manual {
+      vertical-align: super;
+    }
+  }
+}

--- a/app/javascript/charity-split.js
+++ b/app/javascript/charity-split.js
@@ -15,6 +15,9 @@ export function enableCharitySplit(sliders) {
   const ranges = Array.from(sliders.querySelectorAll('input[type="range"]'));
   let donationAmount = GBP(elements['donation[amount]'].value);
 
+  const sumWarning = form.querySelector('.sum-warning');
+  const submitButton = form.querySelector('button');
+
   listItems.forEach((slider) => {
     let range = slider.querySelector('input[type="range"]');
     range.min = 0;
@@ -56,7 +59,7 @@ export function enableCharitySplit(sliders) {
 
       updateLabel(event.target);
 
-      correctDisparity(ranges, otherRanges, donationAmount);
+      correctDisparity(ranges, otherRanges, donationAmount, sumWarning, submitButton);
     });
   });
 
@@ -108,11 +111,23 @@ function updateLabel(range) {
   amountText.value = GBP(range.value, { fromCents: true }).format();
 }
 
-function correctDisparity(ranges, otherRanges, fullAmount) {
-  const sum = ranges.reduce((amount, range) => amount.add(GBP(range.value, { fromCents: true })), GBP(0));
+function correctDisparity(ranges, otherRanges, fullAmount, sumWarning, submitButton) {
+  let sum = ranges.reduce((amount, range) => amount.add(GBP(range.value, { fromCents: true })), GBP(0));
   const disparity = fullAmount.subtract(sum);
+
+  sumWarning.setAttribute('hidden', '');
+  submitButton.removeAttribute('disabled');
 
   if (disparity.intValue != 0) {
     distribute(disparity, otherRanges.filter(r => GBP(r.value, { fromCents: true }).intValue > 0));
+  }
+
+  sum = ranges.reduce((amount, range) => amount.add(GBP(range.value, { fromCents: true })), GBP(0));
+
+  // There are ways that this still might not add up, for instance if the user
+  // has locked some of the sliders.
+  if (sum.intValue != fullAmount.intValue) {
+    sumWarning.removeAttribute('hidden');
+    submitButton.setAttribute('disabled', '');
   }
 }

--- a/app/javascript/charity-split.js
+++ b/app/javascript/charity-split.js
@@ -16,14 +16,16 @@ export function enableCharitySplit(sliders) {
   const donationAmount = GBP(elements.amount.value);
 
   listItems.forEach((slider) => {
-    let amountText = document.createElement('p');
-    amountText.className = "amount";
-    slider.append(amountText);
-
     let range = slider.querySelector('input[type="range"]');
     range.min = 0;
     range.value = 0;
     updateLabel(range);
+
+    slider.querySelector('input.manual')
+      .addEventListener('change', event => {
+        range.value = GBP(event.target.value).intValue;
+        range.dispatchEvent(new InputEvent('input'));
+      });
 
     range.addEventListener('input', (event) => {
       let otherRanges = Array.from(event.target.closest('ul').querySelectorAll('input[type="range"]'));
@@ -89,8 +91,8 @@ function distribute(fullAmount, ranges) {
 }
 
 function updateLabel(range) {
-  let amountText = range.closest('li').querySelector('p.amount');
-  amountText.textContent = GBP(range.value, { fromCents: true }).format();
+  let amountText = range.closest('li').querySelector('input.manual');
+  amountText.value = GBP(range.value, { fromCents: true }).format();
 }
 
 function correctDisparity(ranges, fullAmount) {

--- a/app/javascript/charity-split.js
+++ b/app/javascript/charity-split.js
@@ -1,0 +1,103 @@
+import currency from "currency.js"
+
+const GBP = (value, options) => currency(value, Object.assign({}, (options || {}), { symbol: '£' }));
+
+export function enableCharitySplit(sliders) {
+  if (sliders === undefined) {
+    return;
+  }
+
+  sliders.removeAttribute('hidden');
+
+  const form = sliders.closest('form');
+  const elements = form.elements;
+  const listItems = Array.from(sliders.children);
+  const ranges = Array.from(sliders.querySelectorAll('input[type="range"]'));
+  const donationAmount = GBP(elements.amount.value);
+
+  listItems.forEach((slider) => {
+    let amountText = document.createElement('p');
+    amountText.className = "amount";
+    slider.append(amountText);
+
+    let range = slider.querySelector('input[type="range"]');
+    range.min = 0;
+    range.value = 0;
+    updateLabel(range);
+
+    range.addEventListener('input', (event) => {
+      let otherRanges = Array.from(event.target.closest('ul').querySelectorAll('input[type="range"]'));
+      otherRanges = otherRanges.filter(r => r.id != event.target.id);
+      let amount = GBP(event.target.value, { fromCents: true });
+      let previousAmount = GBP(event.target.dataset.previousAmount, { fromCents: true });
+
+      if (event.target.value == event.target.max) {
+        otherRanges.forEach(r => {
+          r.value = 0;
+          r.dataset.previousAmount = 0;
+          updateLabel(r);
+        });
+      } else {
+        let inverted = GBP(0).subtract(amount.subtract(previousAmount));
+        distribute(inverted, otherRanges);
+      }
+
+      event.target.dataset.previousAmount = event.target.value;
+
+      updateLabel(event.target);
+
+      correctDisparity(ranges, donationAmount);
+    });
+  });
+
+  updateRangeCaps(donationAmount, ranges)
+  distribute(donationAmount, ranges);
+  ranges.forEach(range => {
+    range.dataset.previousAmount = range.value;
+  });
+
+  elements.amount.addEventListener('change', (event) => {
+    const donationAmount = GBP(event.target.value);
+
+    updateRangeCaps(donationAmount, ranges);
+    resetValues(ranges);
+    distribute(donationAmount, ranges);
+  });
+}
+
+function updateRangeCaps(maxAmount, ranges) {
+  ranges.forEach(range => {
+    range.max = maxAmount.intValue;
+  });
+}
+
+function resetValues(ranges) {
+  ranges.forEach(range => {
+    range.value = 0;
+    updateLabel(range);
+  });
+}
+
+function distribute(fullAmount, ranges) {
+  let evenSplit = fullAmount.distribute(ranges.length);
+
+  ranges.forEach((range, i) => {
+    range.dataset.previousAmount = range.value;
+    range.value = GBP(range.value, { fromCents: true }).add(evenSplit[i]).intValue;
+    updateLabel(range);
+  });
+}
+
+function updateLabel(range) {
+  let amountText = range.closest('li').querySelector('p.amount');
+  amountText.textContent = GBP(range.value, { fromCents: true }).format();
+}
+
+function correctDisparity(ranges, fullAmount) {
+  const sum = ranges.reduce((amount, range) => amount.add(GBP(range.value, { fromCents: true })), GBP(0));
+  const disparity = fullAmount.subtract(sum);
+
+  if (disparity.intValue != 0) {
+    distribute(disparity, ranges.filter(r => GBP(r.value, { fromCents: true }).intValue > 0));
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 
 export * from "../stripe/checkout"
+export * from "../charity-split"
 
 Rails.start()
 ActiveStorage.start()

--- a/app/javascript/stripe/checkout.js
+++ b/app/javascript/stripe/checkout.js
@@ -1,29 +1,25 @@
 export function addStripeToForm(form) {
-  if (form.dataset.testMode == "true") {
-    return
-  }
-
-  var stripe = Stripe(form.dataset.stripePublicKey);
-
   form.addEventListener('submit', function(event) {
+    const targetForm = event.target;
+    const disabledFields = Array.from(targetForm.querySelectorAll('input:disabled'));
+
+    disabledFields.forEach(field => field.disabled = false);
+
+    if (form.dataset.testMode == "true") {
+      return
+    }
+
     event.preventDefault()
 
-    const targetForm = event.target;
-
-    const elements = targetForm.elements;
     const csrfToken = document.querySelector("[name='csrf-token']").content
+    const stripe = Stripe(form.dataset.stripePublicKey);
 
     fetch(targetForm.action, {
       method: 'POST',
       headers: {
         "X-CSRF-Token": csrfToken,
-        "Content-Type": "application/json"
       },
-      body: JSON.stringify({
-        currency: elements.currency.value,
-        amount: elements.amount.value,
-        message: elements.message.value,
-      })
+      body: (new FormData(targetForm)),
     })
     .then(function(response) {
       return response.json();
@@ -40,5 +36,4 @@ export function addStripeToForm(form) {
       console.error('Error:', error);
     });
   });
-
 }

--- a/app/models/charity.rb
+++ b/app/models/charity.rb
@@ -14,4 +14,6 @@
 #
 class Charity < ApplicationRecord
   validates :name, presence: true
+
+  has_many :charity_splits, inverse_of: :charity, dependent: :destroy
 end

--- a/app/models/charity_split.rb
+++ b/app/models/charity_split.rb
@@ -1,0 +1,22 @@
+# ## Schema Information
+#
+# Table name: `charity_splits`
+#
+# ### Columns
+#
+# Name                   | Type               | Attributes
+# ---------------------- | ------------------ | ---------------------------
+# **`id`**               | `bigint`           | `not null, primary key`
+# **`amount_currency`**  | `string`           | `default("GBP"), not null`
+# **`amount_decimals`**  | `integer`          | `default(0), not null`
+# **`created_at`**       | `datetime`         | `not null`
+# **`updated_at`**       | `datetime`         | `not null`
+# **`charity_id`**       | `bigint`           |
+# **`donation_id`**      | `bigint`           |
+#
+class CharitySplit < ApplicationRecord
+  belongs_to :donation, inverse_of: :charity_splits
+  belongs_to :charity, inverse_of: :charity_splits
+
+  monetize :amount
+end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -26,6 +26,12 @@ class Donation < ApplicationRecord
   has_many :charity_splits, inverse_of: :donation, dependent: :destroy
   accepts_nested_attributes_for :charity_splits
 
+  before_save do
+    if charity_splits.all? { |s| s.amount.zero? }
+      self.charity_splits = []
+    end
+  end
+
   monetize :amount
 
   include AASM

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -23,6 +23,9 @@ class Donation < ApplicationRecord
   belongs_to :donated_by, inverse_of: :donations, optional: true, class_name: "Donator"
   belongs_to :curated_streamer, inverse_of: :donations, optional: true
 
+  has_many :charity_splits, inverse_of: :donation, dependent: :destroy
+  accepts_nested_attributes_for :charity_splits
+
   monetize :amount
 
   include AASM
@@ -44,6 +47,20 @@ class Donation < ApplicationRecord
     event :fulfill do
       transitions from: :paid, to: :fulfilled
     end
+  end
+
+  def initialize(*_)
+    super
+
+    if charity_splits.none?
+      Charity.all.find_each do |charity|
+        charity_splits.build(charity: charity)
+      end
+    end
+  end
+
+  def charity_name
+    charity&.name
   end
 
   def state

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -3,6 +3,7 @@
   <script type="text/javascript">
     onReady(function() {
       Packs.application.addStripeToForm(document.getElementById('donation-form'));
+      Packs.application.enableCharitySplit(document.getElementsByClassName('charity-split')[0]);
     })
   </script>
 <% end %>
@@ -19,6 +20,17 @@
     <%= label_tag :amount %>
     <%= text_field_tag :amount, "25.00" %>
   </p>
+
+  <ul class="charity-split" hidden>
+    <%= fields_for :charity_split do |fields| %>
+      <% Charity.find_each do |charity| %>
+        <li>
+          <p><%= fields.label "charity_#{charity.id}", charity.name %></p>
+          <p><%= fields.range_field "charity_#{charity.id}" %></p>
+        </li>
+      <% end %>
+    <% end %>
+  </ul>
 
   <p>
     <%= label_tag :message, "Message (optional)" %>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -44,5 +44,10 @@
 
   <%= form.hidden_field :curated_streamer_id %>
 
+  <div class="sum-warning" hidden>
+    <p>Your donation split doesn't add up to your total donation amount.</p>
+    <p>Please correct this and try again.</p>
+  </div>
+
   <button id="stripe-donate">Donate</button>
 <% end %>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -10,39 +10,39 @@
 
 <h2>Make a donation</h2>
 
-<%= form_tag stripe_prep_checkout_path, id: "donation-form", :'data-stripe-public-key' => ENV["STRIPE_PUBLIC_KEY"], :'data-test-mode' => Rails.env.test? do %>
+<%= form_for Donation.new(amount: "25.00", curated_streamer: (local_assigns.has_key?(:streamer) && streamer)), url: stripe_prep_checkout_path, html: { id: "donation-form", :'data-stripe-public-key' => ENV["STRIPE_PUBLIC_KEY"], :'data-test-mode' => Rails.env.test? } do |form| %>
   <p>
-    <%= label_tag :currency %>
-    <%= select_tag :currency, options_for_select(Currency.present_all, Currency::DEFAULT_CURRENCY.downcase) %>
+    <%= form.label :amount_currency, "Currency" %>
+    <%= form.select :amount_currency, options_for_select(Currency.present_all, Currency::DEFAULT_CURRENCY.downcase) %>
   </p>
 
   <p>
-    <%= label_tag :amount %>
-    <%= text_field_tag :amount, "25.00", class: "amount" %>
+    <%= form.label :amount %>
+    <%= form.text_field :amount, html: { class: "amount" } %>
   </p>
 
   <ul class="charity-split" hidden>
-    <%= fields_for :charity_split do |fields| %>
-      <% Charity.find_each do |charity| %>
-        <li>
-          <p><%= fields.label "charity_#{charity.id}", charity.name %></p>
-          <p>
-            <%= fields.range_field "charity_#{charity.id}" %>
-            <input type="text" class="manual amount" />
-          </p>
-        </li>
-      <% end %>
+    <%= form.fields_for :charity_splits do |fields| %>
+      <li data-charity-id="<%= fields.object.charity.id %>">
+        <p><%= fields.label :amount_decimals, fields.object.charity.name %></p>
+        <p>
+          <%= fields.range_field :amount_decimals %>
+          <%= text_field_tag "donation[charity_splits_attributes][#{fields.index}][manual]", nil, class: "manual amount" %>
+
+          <%= check_box_tag "donation[charity_splits_attributes][#{fields.index}][lock]", "1", false, class: "lock" %>
+          <%= label_tag "donation[charity_splits_attributes][#{fields.index}][lock]", "Lock slider" %>
+        </p>
+        <%= fields.hidden_field :charity_id %>
+      </li>
     <% end %>
   </ul>
 
   <p>
-    <%= label_tag :message, "Message (optional)" %>
-    <%= text_field_tag :message %>
+    <%= form.label :message, "Message (optional)" %>
+    <%= form.text_field :message %>
   </p>
 
-  <% if local_assigns.has_key?(:streamer) && streamer.present? %>
-    <%= hidden_field_tag :curated_streamer_id, streamer.id %>
-  <% end %>
+  <%= form.hidden_field :curated_streamer_id %>
 
   <button id="stripe-donate">Donate</button>
 <% end %>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -18,7 +18,7 @@
 
   <p>
     <%= label_tag :amount %>
-    <%= text_field_tag :amount, "25.00" %>
+    <%= text_field_tag :amount, "25.00", class: "amount" %>
   </p>
 
   <ul class="charity-split" hidden>
@@ -26,7 +26,10 @@
       <% Charity.find_each do |charity| %>
         <li>
           <p><%= fields.label "charity_#{charity.id}", charity.name %></p>
-          <p><%= fields.range_field "charity_#{charity.id}" %></p>
+          <p>
+            <%= fields.range_field "charity_#{charity.id}" %>
+            <input type="text" class="manual amount" />
+          </p>
         </li>
       <% end %>
     <% end %>

--- a/app/views/donations/_list.html.erb
+++ b/app/views/donations/_list.html.erb
@@ -10,7 +10,12 @@
   <tbody>
     <% donations.each do |donation| %>
       <tr>
-        <td><%= donation.amount.format %></td>
+        <td>
+          <%= donation.amount.format %>
+          <% donation.charity_splits.each do |split| %>
+            <%= split.charity.name %>: <%= split.amount.format %>
+          <% end %>
+        </td>
         <td><%= donation.state.humanize %></td>
         <td><%= donation.message %></td>
         <td><%= donation.donated_by&.name || (donation.donator == current_donator ? "You" : donation.donator.display_name) %></td>

--- a/app/views/donations/_list.html.erb
+++ b/app/views/donations/_list.html.erb
@@ -8,7 +8,7 @@
     </tr>
   </thead>
   <tbody>
-    <% donations.each do |donation| %>
+    <% donations.select(&:persisted?).each do |donation| %>
       <tr>
         <td>
           <%= donation.amount.format %>

--- a/db/migrate/20210630172231_create_charity_split.rb
+++ b/db/migrate/20210630172231_create_charity_split.rb
@@ -1,0 +1,13 @@
+class CreateCharitySplit < ActiveRecord::Migration[6.1]
+  def change
+    create_table :charity_splits do |t|
+      t.belongs_to :donation
+      t.belongs_to :charity
+
+      t.string :amount_currency, null: false, default: "GBP"
+      t.integer :amount_decimals, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_03_120434) do
+ActiveRecord::Schema.define(version: 2021_06_30_172231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,17 @@ ActiveRecord::Schema.define(version: 2021_06_03_120434) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_charities_on_name"
+  end
+
+  create_table "charity_splits", force: :cascade do |t|
+    t.bigint "donation_id"
+    t.bigint "charity_id"
+    t.string "amount_currency", default: "GBP", null: false
+    t.integer "amount_decimals", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["charity_id"], name: "index_charity_splits_on_charity_id"
+    t.index ["donation_id"], name: "index_charity_splits_on_donation_id"
   end
 
   create_table "curated_streamer_administrators", force: :cascade do |t|

--- a/features/charities/donation_split.feature
+++ b/features/charities/donation_split.feature
@@ -4,6 +4,10 @@ Scenario: Donator splits their donation explicitly
   When a donator splits their donation unevenly among the charities
   Then the donation split should appear on their donations list
 
+Scenario: Donator's split doesn't add up
+  When a donator splits their donation in a way that doesn't add up to their total donation
+  Then the donator should be asked to correct their split
+
 @admin
 Scenario: Regular admins cannot access the accounting page
   When the admin goes to the admin section

--- a/features/charities/donation_split.feature
+++ b/features/charities/donation_split.feature
@@ -3,3 +3,14 @@ Feature: Charities: donation split
 Scenario: Donator splits their donation explicitly
   When a donator splits their donation unevenly among the charities
   Then the donation split should appear on their donations list
+
+@admin
+Scenario: Regular admins cannot access the accounting page
+  When the admin goes to the admin section
+  Then they should not see the donation accounting section
+
+@admin
+@support
+Scenario: Admin views aggregate donation splits
+  Given a variety of split and unsplit donations
+  Then the admin should be able to see a breakdown of amounts owed to each charity

--- a/features/charities/donation_split.feature
+++ b/features/charities/donation_split.feature
@@ -1,0 +1,5 @@
+Feature: Charities: donation split
+
+Scenario: Donator splits their donation explicitly
+  When a donator splits their donation unevenly among the charities
+  Then the donation split should appear on their donations list

--- a/features/step_definitions/charities/donation_split_steps.rb
+++ b/features/step_definitions/charities/donation_split_steps.rb
@@ -47,11 +47,23 @@ Given("a variety of split and unsplit donations") do
   @popular_charity = FactoryBot.create(:charity, name: "Popular charity")
   @unpopular_charity = FactoryBot.create(:charity, name: "Unpopular charity")
 
-  FactoryBot.create(:donation, amount: Money.new(30_00, "GBP")) # £15 to each
+  # £15/£15
+  FactoryBot.create(:donation, amount: Money.new(30_00, "GBP"))
+
+  # £25/£5
   FactoryBot.create(:donation,
     amount: Money.new(30_00, "GBP"),
     charity_split: {
       @popular_charity => Money.new(25_00, "GBP"),
+      @unpopular_charity => Money.new(5_00, "GBP"),
+    },
+  )
+
+  # £10/£5/(£7.50/£7.50)
+  FactoryBot.create(:donation,
+    amount: Money.new(30_00, "GBP"),
+    charity_split: {
+      @popular_charity => Money.new(10_00, "GBP"),
       @unpopular_charity => Money.new(5_00, "GBP"),
     },
   )
@@ -60,8 +72,11 @@ end
 Then("the admin should be able to see a breakdown of amounts owed to each charity") do
   go_to_admin_area("Donation accounting")
 
-  expect(page).to have_text("Popular charity #{Money.new(40_00, 'GBP').format}")
-  expect(page).to have_text("Unpopular charity #{Money.new(20_00, 'GBP').format}")
+  # 15 + 25 + 10 + 7.50 = 57.50
+  expect(page).to have_text("Popular charity #{Money.new(57_50, 'GBP').format}")
+
+  # 15 + 5 + 5 + 7.50 = 32.50
+  expect(page).to have_text("Unpopular charity #{Money.new(32_50, 'GBP').format}")
 end
 
 When("the admin goes to the admin section") do

--- a/features/step_definitions/charities/donation_split_steps.rb
+++ b/features/step_definitions/charities/donation_split_steps.rb
@@ -23,6 +23,26 @@ Then("the donation split should appear on their donations list") do
   expect(page).to have_text("#{@charity_3.name}: #{@split_3.format}")
 end
 
+When("a donator splits their donation in a way that doesn't add up to their total donation") do
+  @charity_1 = FactoryBot.create(:charity)
+  @charity_2 = FactoryBot.create(:charity)
+  @charity_3 = FactoryBot.create(:charity)
+
+  make_donation(Money.new(30_00, "GBP"),
+    navigate: true,
+    submit: false,
+    split: {
+      @charity_1 => Money.new(20_00, "GBP"),
+      @charity_2 => Money.new(0),
+      @charity_3 => Money.new(0),
+    },
+  )
+end
+
+Then("the donator should be asked to correct their split") do
+  expect(page).to have_text("Your donation split doesn't add up to your total donation amount.")
+end
+
 Given("a variety of split and unsplit donations") do
   @popular_charity = FactoryBot.create(:charity, name: "Popular charity")
   @unpopular_charity = FactoryBot.create(:charity, name: "Unpopular charity")

--- a/features/step_definitions/charities/donation_split_steps.rb
+++ b/features/step_definitions/charities/donation_split_steps.rb
@@ -22,3 +22,32 @@ Then("the donation split should appear on their donations list") do
   expect(page).to have_text("#{@charity_2.name}: #{@split_2.format}")
   expect(page).to have_text("#{@charity_3.name}: #{@split_3.format}")
 end
+
+Given("a variety of split and unsplit donations") do
+  @popular_charity = FactoryBot.create(:charity, name: "Popular charity")
+  @unpopular_charity = FactoryBot.create(:charity, name: "Unpopular charity")
+
+  FactoryBot.create(:donation, amount: Money.new(30_00, "GBP")) # £15 to each
+  FactoryBot.create(:donation,
+    amount: Money.new(30_00, "GBP"),
+    charity_split: {
+      @popular_charity => Money.new(25_00, "GBP"),
+      @unpopular_charity => Money.new(5_00, "GBP"),
+    },
+  )
+end
+
+Then("the admin should be able to see a breakdown of amounts owed to each charity") do
+  go_to_admin_area("Donation accounting")
+
+  expect(page).to have_text("Popular charity #{Money.new(40_00, 'GBP').format}")
+  expect(page).to have_text("Unpopular charity #{Money.new(20_00, 'GBP').format}")
+end
+
+When("the admin goes to the admin section") do
+  go_to_admin_homepage
+end
+
+Then("they should not see the donation accounting section") do
+  expect(page).not_to have_text("Donation accounting")
+end

--- a/features/step_definitions/charities/donation_split_steps.rb
+++ b/features/step_definitions/charities/donation_split_steps.rb
@@ -1,0 +1,24 @@
+When("a donator splits their donation unevenly among the charities") do
+  @amount = Money.new(30_00, "GBP")
+
+  @charity_1 = FactoryBot.create(:charity)
+  @charity_2 = FactoryBot.create(:charity)
+  @charity_3 = FactoryBot.create(:charity)
+
+  make_donation(@amount,
+    navigate: true,
+    split: {
+      @charity_1 => (@split_1 = Money.new(20_00, "GBP")),
+      @charity_2 => (@split_2 = Money.new(6_00, "GBP")),
+      @charity_3 => (@split_3 = Money.new(4_00, "GBP")),
+    },
+  )
+end
+
+Then("the donation split should appear on their donations list") do
+  expect(page).to have_text(@amount.format)
+
+  expect(page).to have_text("#{@charity_1.name}: #{@split_1.format}")
+  expect(page).to have_text("#{@charity_2.name}: #{@split_2.format}")
+  expect(page).to have_text("#{@charity_3.name}: #{@split_3.format}")
+end

--- a/features/step_definitions/curated_streamer_steps.rb
+++ b/features/step_definitions/curated_streamer_steps.rb
@@ -7,7 +7,7 @@ When("a donator goes to the curated streamer's page") do
 end
 
 When("they make a donation") do
-  @donation_amount = Money.new(500, "GBP")
+  @donation_amount = Money.new(5_00, "GBP")
   @donation_message = "Go team!"
   make_donation(@donation_amount, message: @donation_message)
 end

--- a/features/support/helpers/donation_helpers.rb
+++ b/features/support/helpers/donation_helpers.rb
@@ -1,5 +1,5 @@
 module DonationHelpers
-  def make_donation(amount, split: {}, message: nil, navigate: false)
+  def make_donation(amount, split: {}, message: nil, navigate: false, submit: true)
     if navigate
       go_to_homepage
       click_on "Donate here!"
@@ -20,7 +20,7 @@ module DonationHelpers
       end
     end
 
-    click_on "Donate"
+    click_on "Donate" if submit
   end
 end
 

--- a/features/support/helpers/donation_helpers.rb
+++ b/features/support/helpers/donation_helpers.rb
@@ -1,5 +1,5 @@
 module DonationHelpers
-  def make_donation(amount, message: nil, navigate: false)
+  def make_donation(amount, split: {}, message: nil, navigate: false)
     if navigate
       go_to_homepage
       click_on "Donate here!"
@@ -8,6 +8,17 @@ module DonationHelpers
     select amount.currency.iso_code, from: "Currency"
     fill_in "Amount", with: amount.to_s
     fill_in "Message", with: message if message
+
+    if split.present?
+      split.each do |charity, split_amount|
+        find("li[data-charity-id='#{charity.id}'] input.manual")
+          .set(split_amount.to_s, clear: :backspace)
+
+        within "li[data-charity-id='#{charity.id}']" do
+          check "Lock slider"
+        end
+      end
+    end
 
     click_on "Donate"
   end

--- a/features/support/helpers/donation_helpers.rb
+++ b/features/support/helpers/donation_helpers.rb
@@ -6,7 +6,7 @@ module DonationHelpers
     end
 
     select amount.currency.iso_code, from: "Currency"
-    fill_in "Amount", with: amount.to_s
+    fill_in "Amount", with: amount.to_s, fill_options: { clear: :backspace }
     fill_in "Message", with: message if message
 
     if split.present?

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.0",
+    "currency.js": "^2.0.3",
     "postcss": "^8.2.10",
     "yarn": "^1.22.10"
   },

--- a/test/factories/donation_factory.rb
+++ b/test/factories/donation_factory.rb
@@ -3,5 +3,19 @@ FactoryBot.define do
     donator
     amount { Money.new(25_000) }
     message { "Some standard message" }
+
+    transient do
+      charity_split { {} }
+    end
+
+    after(:build) do |donation, evaluator|
+      evaluator.charity_split.each do |charity, split_amount|
+        donation.charity_splits.build(
+          donation: donation,
+          charity: charity,
+          amount: split_amount,
+        )
+      end
+    end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,6 +2542,11 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.1.2"
 
+currency.js@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/currency.js/-/currency.js-2.0.4.tgz#a8a4d69be3b2e509bf67a560c78220bc04809cf1"
+  integrity sha512-6/OplJYgJ0RUlli74d93HJ/OsKVBi8lB1+Z6eJYS1YZzBuIp4qKKHpJ7ad+GvTlWmLR/hLJOWTykN5Nm8NJ7+w==
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"


### PR DESCRIPTION
Closes https://github.com/SmartCasual/jingle-jam/issues/12

Adds charity split sliders and an admin page for viewing the aggregate breakdowns.

```
Feature: Charities: donation split

  Scenario: Donator splits their donation explicitly                  # features/charities/donation_split.feature:3
    When a donator splits their donation unevenly among the charities # features/step_definitions/charities/donation_split_steps.rb:1
    Then the donation split should appear on their donations list     # features/step_definitions/charities/donation_split_steps.rb:18

  Scenario: Donator's split doesn't add up                                                    # features/charities/donation_split.feature:7
    When a donator splits their donation in a way that doesn't add up to their total donation # features/step_definitions/charities/donation_split_steps.rb:26
    Then the donator should be asked to correct their split                                   # features/step_definitions/charities/donation_split_steps.rb:42

  @admin
  Scenario: Regular admins cannot access the accounting page # features/charities/donation_split.feature:12
    When the admin goes to the admin section                 # features/step_definitions/charities/donation_split_steps.rb:82
    Then they should not see the donation accounting section # features/step_definitions/charities/donation_split_steps.rb:86

  @admin @support
  Scenario: Admin views aggregate donation splits                                    # features/charities/donation_split.feature:18
    Given a variety of split and unsplit donations                                   # features/step_definitions/charities/donation_split_steps.rb:46
    Then the admin should be able to see a breakdown of amounts owed to each charity # features/step_definitions/charities/donation_split_steps.rb:72

4 scenarios (4 passed)
```