### PR TITLE
Admin user requires a name

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,7 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 if Rails.env.development?
   AdminUser.create!(
+    name: "Admin",
     email: "admin@example.com",
     password: "password",
     password_confirmation: "password",


### PR DESCRIPTION
When testing #71 I noticed the db:seed job was failing because a name was required.