### PR TITLE
Remove link to profile page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
         <div class="donator">
           <% if current_donator&.id %>
             <ul>
-              <li><%= link_to current_donator.display_name, donator_path(current_donator) %></li>
+              <li><%= current_donator.display_name %></li>
               <li><%= button_to t("common.actions.log_out"), logout_path %></li>
             </ul>
           <% end %>


### PR DESCRIPTION
This part of the site doesn't currently do anything.

## Before (link)
<img width="276" alt="Screenshot 2022-04-11 at 11 41 46" src="https://user-images.githubusercontent.com/109225/162724159-4b6b37da-bd65-4dbf-ae4a-097b1429a966.png">

## After (plain text)
<img width="248" alt="Screenshot 2022-04-11 at 11 42 57" src="https://user-images.githubusercontent.com/109225/162724180-853820c2-e3a5-4a4a-9e5e-525942c597d6.png">

