### PR TITLE
Add an admin summary of assigned and unassigned keys

### DIFF
--- a/app/admin/games.rb
+++ b/app/admin/games.rb
@@ -14,6 +14,12 @@ ActiveAdmin.register Game do
     id_column
     column :name
     column :description
+    column :unassigned_keys do |game|
+      game.keys.unassigned.count
+    end
+    column :assigned_keys do |game|
+      game.keys.assigned.count
+    end
     column :created_at
     column :updated_at
 
@@ -45,12 +51,12 @@ ActiveAdmin.register Game do
   show do
     attributes_table do
       row :name
-    end
-
-    panel "Keys" do
-      table_for game.keys do
-        column :code
-        column :assigned, &:assigned?
+      row :description
+      row :unassigned_keys do |game|
+        game.keys.unassigned.count
+      end
+      row :assigned_keys do |game|
+        game.keys.assigned.count
       end
     end
 

--- a/features/admin/keys.feature
+++ b/features/admin/keys.feature
@@ -1,0 +1,10 @@
+@admin
+Feature: Admin: keys
+
+Scenario: A key summary is shown to admins
+  Given 3 unassigned keys for the game "Halo"
+  And 2 unassigned keys for the game "Fire Emblem"
+  And 2 assigned keys for the game "Halo"
+  And 3 assigned keys for the game "Fire Emblem"
+  Then a summary should be available on the game index page
+  And a summary should be available on the game show page

--- a/features/step_definitions/admin/csv_upload_steps.rb
+++ b/features/step_definitions/admin/csv_upload_steps.rb
@@ -23,6 +23,5 @@ end
 Then("the game keys should be added to that game") do
   go_to_admin_game(@game)
 
-  expect(page).to have_css(".col-code", count: @keys.count + 1)
-  @keys.each { |k| expect(page).to have_text(k) }
+  expect(page).to have_css(".row-unassigned_keys td", text: @keys.count)
 end

--- a/features/step_definitions/admin/game_steps.rb
+++ b/features/step_definitions/admin/game_steps.rb
@@ -47,26 +47,23 @@ end
 
 When("the keys should be on the admin page for that game") do
   go_to_admin_game(@current_game)
-
-  @key_codes.each do |key_code|
-    expect(page).to have_css(".col-code", text: key_code)
-  end
+  expect(page).to have_css(".row-unassigned_keys", text: @key_codes.count)
 end
 
 When("the key shouldn't be on the admin page for that game") do
   go_to_admin_game(@current_game)
-  expect(page).not_to have_css(".col-code", text: @deleted_code)
+  expect(page).to have_css(".row-unassigned_keys", text: @current_game.keys.count)
 end
 
 When("an admin edits the game") do
   go_to_admin_game(@current_game, edit: true)
-  fill_in "Name", with: (@new_name = SecureRandom.uuid)
+  fill_in "Name", with: (@new_name = SecureRandom.uuid), fill_options: { clear: :backspace }
   click_on "Update Game"
 end
 
 When("an admin edits a key") do
   go_to_admin_game(@current_game, edit: true)
-  fill_in "Code", with: (@new_code = SecureRandom.uuid), currently_with: @current_game.keys.first.code
+  fill_in "Code", with: (@new_code = SecureRandom.uuid), currently_with: @current_game.keys.first.code, fill_options: { clear: :backspace }
   click_on "Update Game"
 end
 
@@ -77,7 +74,7 @@ end
 
 Then("the edits to the key should've been saved") do
   go_to_admin_game(@current_game)
-  expect(page).to have_css(".col-code", text: @new_code)
+  expect(@current_game.reload.keys.map(&:code)).to include(@new_code)
 end
 
 When("an admin deletes the game") do

--- a/features/step_definitions/admin/key_steps.rb
+++ b/features/step_definitions/admin/key_steps.rb
@@ -1,0 +1,35 @@
+Given("{int} unassigned keys for the game {string}") do |count, game_name|
+  game = Game.find_by(name: game_name) || create(:game, name: game_name)
+  create_list(:key, count, :unassigned, game:)
+end
+
+Given("{int} assigned keys for the game {string}") do |count, game_name|
+  game = Game.find_by(name: game_name) || create(:game, name: game_name)
+  create_list(:key, count, :assigned, game:)
+end
+
+Then("a summary should be available on the game index page") do
+  go_to_admin_games
+
+  row = page.find(".col-name", text: "Halo").ancestor("tr")
+  within row do
+    expect(page).to have_css(".col-unassigned_keys", text: "3")
+    expect(page).to have_css(".col-assigned_keys", text: "2")
+  end
+
+  row = page.find(".col-name", text: "Fire Emblem").ancestor("tr")
+  within row do
+    expect(page).to have_css(".col-unassigned_keys", text: "2")
+    expect(page).to have_css(".col-assigned_keys", text: "3")
+  end
+end
+
+Then("a summary should be available on the game show page") do
+  go_to_admin_game("Halo")
+  expect(page).to have_css(".row-unassigned_keys", text: "3")
+  expect(page).to have_css(".row-assigned_keys", text: "2")
+
+  go_to_admin_game("Fire Emblem")
+  expect(page).to have_css(".row-unassigned_keys", text: "2")
+  expect(page).to have_css(".row-assigned_keys", text: "3")
+end

--- a/features/support/helpers/admin/navigation_helpers.rb
+++ b/features/support/helpers/admin/navigation_helpers.rb
@@ -18,6 +18,7 @@ module Admin::NavigationHelpers
   end
 
   def go_to_admin_game(game, edit: false)
+    game = Game.find_by(name: game) if game.is_a?(String)
     go_to_admin_record(game, within: "Games", edit:)
   end
 

--- a/test/factories/key_factory.rb
+++ b/test/factories/key_factory.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     donator_bundle_tier { nil }
 
     trait :unassigned
+
+    trait :assigned do
+      donator_bundle_tier
+    end
   end
 end


### PR DESCRIPTION
- Summary per game row on the Games admin page
- Summary per game on the game's admin page

<img width="837" alt="Screenshot 2022-05-11 at 22 11 17" src="https://user-images.githubusercontent.com/109225/167951456-8f6d72d3-da5e-4e4f-b950-cfa99206dee4.png">