### PR TITLE
Fix a bug where lots of bundles would be assigned

### DIFF
--- a/app/controllers/account/bundles_controller.rb
+++ b/app/controllers/account/bundles_controller.rb
@@ -6,6 +6,7 @@ class Account::BundlesController < ApplicationController
     @bundles_by_fundraiser = current_donator
       .donator_bundles
       .includes(bundle: :fundraiser)
+      .reject(&:fully_locked?)
       .group_by { |b| b.bundle.fundraiser }
   end
 

--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -63,4 +63,8 @@ class Bundle < ApplicationRecord
   def total_value
     highest_tier.price
   end
+
+  def currency
+    highest_tier&.price_currency
+  end
 end

--- a/app/models/donator_bundle.rb
+++ b/app/models/donator_bundle.rb
@@ -35,12 +35,20 @@ class DonatorBundle < ApplicationRecord
     locked_tiers.none?
   end
 
+  def incomplete?
+    !complete?
+  end
+
   def next_unlockable_tier
     unlockable_tiers.first
   end
 
   def unlockable_tiers_at_or_below(amount)
     unlockable_tiers.where("price_decimals <= ?", amount.fractional)
+  end
+
+  def fully_locked?
+    locked_tiers == donator_bundle_tiers
   end
 
 private

--- a/spec/models/bundle_spec.rb
+++ b/spec/models/bundle_spec.rb
@@ -73,4 +73,22 @@ RSpec.describe Bundle, type: :model do
       expect(bundle).not_to be_valid
     end
   end
+
+  describe "#currency" do
+    context "if the bundle has no tiers" do
+      it "returns nil" do
+        expect(bundle.currency).to be_nil
+      end
+    end
+
+    context "if the bundle has tiers" do
+      let(:attrs) { { bundle_tiers: [tier] } }
+
+      let(:tier) { build(:bundle_tier, price: Money.new(1_00, "GBP")) }
+
+      it "returns the currency of the highest tier" do
+        expect(bundle.currency).to eq("GBP")
+      end
+    end
+  end
 end

--- a/spec/models/donator_bundle_spec.rb
+++ b/spec/models/donator_bundle_spec.rb
@@ -79,6 +79,36 @@ RSpec.describe DonatorBundle, type: :model do
     end
   end
 
+  describe "#incomplete?" do
+    it "is the inverse of #complete?" do
+      expect(donator_bundle.incomplete?).to eq(!donator_bundle.complete?)
+    end
+  end
+
+  describe "#fully_locked?" do
+    subject { donator_bundle.fully_locked? }
+
+    context "when no donator bundle tiers are unlocked" do
+      it { is_expected.to be(true) }
+    end
+
+    context "when some donator bundle tiers are unlocked" do
+      before do
+        donator_bundle.donator_bundle_tiers.first.unlock!
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when all donator bundle tiers are unlocked" do
+      before do
+        donator_bundle.donator_bundle_tiers.each(&:unlock!)
+      end
+
+      it { is_expected.to be(false) }
+    end
+  end
+
   describe "#next_unlockable_tier" do
     subject(:result) { donator_bundle.next_unlockable_tier }
 


### PR DESCRIPTION
This was a combination of currency conversions and assumptions about
tier prices.

It should also now never create another bundle (even a fully locked one)
when an incomplete bundle already exists.

As a belt-and-braces, I've also excluded fully-locked bundles from the
user's visible list, since they're of no use to them (and shouldn't exist).

Fixes https://github.com/SmartCasual/jingle-jam/issues/177