### PR TITLE
Fix a bug with logging in via requested token URLs

### DIFF
--- a/app/controllers/account/omniauth_callbacks_controller.rb
+++ b/app/controllers/account/omniauth_callbacks_controller.rb
@@ -24,6 +24,8 @@ class Account::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 private
 
   def confirm_email_address(donator)
+    return if omniauth_email_address.blank?
+
     donator.confirm if donator.email_address == omniauth_email_address
   end
 

--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -35,7 +35,10 @@ class NotificationsMailer < ApplicationMailer
     return if email_address.blank?
     return if (donator = Donator.confirmed.find_by(email_address:)).blank?
 
-    @token_url = log_in_via_token_account_url(donator, token: donator.token, email_address: donator.email_address)
+    @token_url = log_in_via_token_account_url(donator,
+      token: donator.token_with_email_address,
+      email_address: donator.email_address,
+    )
 
     mail to: donator.email_address
   end

--- a/features/donator_accounts/log_in_via_token.feature
+++ b/features/donator_accounts/log_in_via_token.feature
@@ -4,6 +4,7 @@ Scenario: Donator with a confirmed email address requests a log in URL
   Given a donator with a confirmed email address
   When they request a log in URL
   Then they should receive a log in URL
+  And they should be able to log in with that URL
 
 Scenario: Donator with an unconfirmed email address requests a log in URL
   Given a donator with an unconfirmed email address

--- a/features/step_definitions/donator_accounts/log_in_via_token_steps.rb
+++ b/features/step_definitions/donator_accounts/log_in_via_token_steps.rb
@@ -23,9 +23,17 @@ When("someone requests a log in URL for a non-existent account") do
 end
 
 Then("they should receive a log in URL") do
-  expect(find_email_with_link(%r{/log-in-via-token/})).to be_present
+  email = find_email_with_link(%r{/log-in-via-token/})
+  expect(email).to be_present
+  @log_in_url = find_link(email, %r{/log-in-via-token/})
 end
 
 Then("they should not receive a log in URL") do
   expect(find_email_with_link(%r{/log-in-via-token/})).not_to be_present
+end
+
+Then("they should be able to log in with that URL") do
+  visit @log_in_url
+  click_on "Log in via token"
+  expect_logged_in(@donator)
 end

--- a/features/support/helpers/account_test_helpers.rb
+++ b/features/support/helpers/account_test_helpers.rb
@@ -1,9 +1,9 @@
 module AccountTestHelpers
-  def expect_logged_in(_donator)
+  def expect_logged_in(donator = nil)
     expect(page).not_to have_text("Invalid credentials")
 
     within "nav .donator" do
-      expect(page).to have_content(@current_donator.display_name.upcase)
+      expect(page).to have_content((donator || @current_donator).display_name.upcase)
     end
     expect(page).to have_button("Log out")
   end

--- a/spec/controllers/account/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/account/omniauth_callbacks_controller_spec.rb
@@ -2,8 +2,9 @@ RSpec.describe Account::OmniauthCallbacksController, type: :controller do
   include Devise::Test::ControllerHelpers
 
   let(:request) { @request } # rubocop:disable RSpec/InstanceVariable
-  let(:donator) { create(:donator) }
+  let(:donator) { create(:donator, email_address: donator_email_address) }
   let(:email_address) { nil }
+  let(:donator_email_address) { "test@example.com" }
 
   before do
     request.env["devise.mapping"] = Devise.mappings[:donator]
@@ -38,7 +39,7 @@ RSpec.describe Account::OmniauthCallbacksController, type: :controller do
       end
 
       context "if the donator's current email address matches the one provided" do
-        let(:email_address) { donator.email_address }
+        let(:email_address) { donator_email_address }
 
         it "confirms the donator's email address" do
           expect { get :token }.to(change { donator.reload.confirmed_at })
@@ -46,7 +47,16 @@ RSpec.describe Account::OmniauthCallbacksController, type: :controller do
       end
 
       context "if the donator's current email address does not match the one provided" do
-        let(:email_address) { "not-the-same-email-address" }
+        let(:email_address) { "not-the-same-email-address@example.com" }
+
+        it "does not confirm the donator's email address" do
+          expect { get :token }.not_to(change { donator.reload.confirmed_at })
+        end
+      end
+
+      context "if the donator's current email address matches the one provided but they're both blank" do
+        let(:donator_email_address) { "" }
+        let(:email_address) { "" }
 
         it "does not confirm the donator's email address" do
           expect { get :token }.not_to(change { donator.reload.confirmed_at })
@@ -91,7 +101,7 @@ RSpec.describe Account::OmniauthCallbacksController, type: :controller do
       end
 
       context "if the donator's current email address matches the one provided" do
-        let(:email_address) { donator.email_address }
+        let(:email_address) { donator_email_address }
 
         it "confirms the donator's email address" do
           expect { get :twitch }.to(change { donator.reload.confirmed_at })
@@ -99,7 +109,16 @@ RSpec.describe Account::OmniauthCallbacksController, type: :controller do
       end
 
       context "if the donator's current email address does not match the one provided" do
-        let(:email_address) { "not-the-same-email-address" }
+        let(:email_address) { "not-the-same-email-address@example.com" }
+
+        it "does not confirm the donator's email address" do
+          expect { get :twitch }.not_to(change { donator.reload.confirmed_at })
+        end
+      end
+
+      context "if the donator's current email address matches the one provided but they're both blank" do
+        let(:donator_email_address) { "" }
+        let(:email_address) { "" }
 
         it "does not confirm the donator's email address" do
           expect { get :twitch }.not_to(change { donator.reload.confirmed_at })


### PR DESCRIPTION
If the email address is given in the URL then it
must also be in the token, and vice versa.

Fixes https://github.com/SmartCasual/jingle-jam/issues/176