### PR TITLE
Limit donation message length

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -22,6 +22,8 @@
 # **`stripe_payment_intent_id`**  | `string`           |
 #
 class Donation < ApplicationRecord
+  MAX_MESSAGE_LENGTH = 100
+
   belongs_to :donator, inverse_of: :donations
   belongs_to :donated_by, inverse_of: :gifted_donations, optional: true, class_name: "Donator"
   belongs_to :curated_streamer, inverse_of: :donations, optional: true

--- a/app/views/fundraisers/donations/_donation_form.html.erb
+++ b/app/views/fundraisers/donations/_donation_form.html.erb
@@ -60,7 +60,7 @@
 
   <p>
     <%= form.label :message, t("donations.form.message") %>
-    <%= form.text_field :message %>
+    <%= form.text_field :message, maxlength: Donation::MAX_MESSAGE_LENGTH %>
   </p>
 
   <p>

--- a/features/bundles/single-tiered.feature
+++ b/features/bundles/single-tiered.feature
@@ -29,3 +29,10 @@ Scenario: A donator increases their donation above the threshold
 Scenario: A donator leaves a name with their donation
   When a donator makes a £10 donation with the name "Gary Donor"
   Then a £10 donation should be recorded with the name "Gary Donor"
+
+Scenario: A donator leaves a very long donation
+  When a donator tries to make a very long donation using the web form
+  Then the donation message should be cut off in the form
+  And the donation should be recorded with the truncated message
+  When a donator bypasses the donation message truncation in the form
+  Then the donation should still be recorded with the truncated message

--- a/features/step_definitions/bundle_steps.rb
+++ b/features/step_definitions/bundle_steps.rb
@@ -34,3 +34,29 @@ Then("one key per game in the bundle should have been assigned") do
     expect(page).to have_css(".key .code", text: RegexHelpers::UUID_PATTERN)
   end
 end
+
+When("a donator tries to make a very long donation using the web form") do
+  make_donation(
+    message: "a" * 1000,
+    navigate: true,
+    submit: false,
+  )
+end
+
+Then("the donation message should be cut off in the form") do
+  expect(find_field("Message").value).to eq("a" * Donation::MAX_MESSAGE_LENGTH)
+end
+
+Then("the donation should (still )be recorded with the truncated message") do
+  make_donation(
+    message: "a" * 1000,
+    navigate: true,
+    submit: true,
+  )
+
+  expect(Donation.last.message).to eq("a" * Donation::MAX_MESSAGE_LENGTH)
+end
+
+When("a donator bypasses the donation message truncation in the form") do
+  find_field("Message").execute_script("this['maxlength'] = '#{'a' * (Donation::MAX_MESSAGE_LENGTH + 1)}'")
+end

--- a/features/support/helpers/donation_test_helpers.rb
+++ b/features/support/helpers/donation_test_helpers.rb
@@ -3,7 +3,7 @@ require_relative "../../../test/support/request_test_helpers"
 module DonationTestHelpers
   include RequestTestHelpers
 
-  def make_donation(amount, stripe_options: {}, **options) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def make_donation(amount = nil, stripe_options: {}, **options) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     options = {
       email_address: nil,
       message: nil,
@@ -26,6 +26,8 @@ module DonationTestHelpers
       click_on fundraiser.name
       click_on "Donate here!"
     end
+
+    amount ||= fundraiser.bundles.first&.highest_tier&.price
 
     select amount.currency.iso_code, from: "Currency", wait: 5
     fill_in "Amount", with: amount.to_s, fill_options: { clear: :backspace }


### PR DESCRIPTION
Currently set to 100 characters, can be changed if needed.

Closes https://github.com/SmartCasual/jingle-jam/issues/172