### PR TITLE
Provide shorter URLs for curated streamers

### DIFF
--- a/app/controllers/curated_streamers_controller.rb
+++ b/app/controllers/curated_streamers_controller.rb
@@ -7,7 +7,17 @@ class CuratedStreamersController < ApplicationController
   helper DonationHelpers
 
   def show
-    @fundraiser = Fundraiser.find(params[:fundraiser_id])
+    if (fundraiser_id = params[:fundraiser_id]).present?
+      @fundraiser = Fundraiser.find(fundraiser_id)
+    elsif Fundraiser.active.count == 1
+      redirect_to fundraiser_curated_streamer_path(Fundraiser.active.first, @streamer)
+    else
+      redirect_to choose_fundraiser_curated_streamer_path(@streamer)
+    end
+  end
+
+  def choose_fundraiser
+    @fundraisers = Fundraiser.active
   end
 
   def admin; end

--- a/app/views/curated_streamers/choose_fundraiser.html.erb
+++ b/app/views/curated_streamers/choose_fundraiser.html.erb
@@ -1,0 +1,15 @@
+<% if @fundraisers.any? %>
+  <h1>Which fundraiser would you like to donate to?</h1>
+
+  <ul>
+    <% @fundraisers.each do |fundraiser| %>
+      <li>
+        <%= link_to fundraiser.name, fundraiser_curated_streamer_path(fundraiser, @streamer) %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <h1>No active fundraisers</h1>
+
+  <p>Unfortunately there are no fundraisers active at the moment</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,12 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :curated_streamers, path: "streams", only: [:show] do
+      member do
+        get :choose_fundraiser, path: "choose-fundraiser"
+      end
+    end
+
     resource :account, only: %i[show], controller: "account" do
       resources :donations, only: [:index], controller: "account/donations"
       resources :bundles, only: [:index, :show], controller: "account/bundles"

--- a/features/step_definitions/curated_streamer_steps.rb
+++ b/features/step_definitions/curated_streamer_steps.rb
@@ -90,3 +90,21 @@ Then("links to the curated streamers should be listed on the homepage") do
     end
   end
 end
+
+When("a donator goes to the curated streamer's shorter URL") do
+  visit curated_streamer_path(@current_curated_streamer)
+end
+
+Then("the donator should be redirected to the curated streamer's page for the active fundraiser") do
+  expect(current_path).to eq(fundraiser_curated_streamer_path(@first_active_fundraiser, @current_curated_streamer))
+end
+
+Then("the donator should be informed that there are no active fundraisers") do
+  expect(page).to have_text("Unfortunately there are no fundraisers active at the moment")
+end
+
+Then("the donator should be offered links to the curated streamer's page for both active fundraisers") do
+  expect(page).to have_text("Which fundraiser would you like to donate to?")
+  expect(page).to have_link(@first_active_fundraiser.name, href: fundraiser_curated_streamer_path(@first_active_fundraiser, @current_curated_streamer))
+  expect(page).to have_link(@second_active_fundraiser.name, href: fundraiser_curated_streamer_path(@second_active_fundraiser, @current_curated_streamer))
+end

--- a/features/step_definitions/fundraiser_steps.rb
+++ b/features/step_definitions/fundraiser_steps.rb
@@ -1,0 +1,11 @@
+Given("one active fundraiser") do
+  @first_active_fundraiser = create(:fundraiser, :active)
+end
+
+Given("a second active fundraiser") do
+  @second_active_fundraiser = create(:fundraiser, :active)
+end
+
+Given("no active fundraisers") do
+  Fundraiser.active.destroy_all
+end

--- a/features/streaming/curated_streamers.feature
+++ b/features/streaming/curated_streamers.feature
@@ -22,3 +22,15 @@ Scenario: Stream admin views donation stats
 Scenario: Curated streamers are listed on the homepage
   Given several curated streamers
   Then links to the curated streamers should be listed on the homepage
+
+Scenario: Curated streamers get shorter URLs
+  Given a curated streamer
+  But no active fundraisers
+  When a donator goes to the curated streamer's shorter URL
+  Then the donator should be informed that there are no active fundraisers
+  Given one active fundraiser
+  When a donator goes to the curated streamer's shorter URL
+  Then the donator should be redirected to the curated streamer's page for the active fundraiser
+  Given a second active fundraiser
+  When a donator goes to the curated streamer's shorter URL
+  Then the donator should be offered links to the curated streamer's page for both active fundraisers


### PR DESCRIPTION
```
  Scenario: Curated streamers get shorter URLs                                                          # features/streaming/curated_streamers.feature:26
    Given a curated streamer                                                                            # features/step_definitions/curated_streamer_steps.rb:1
    But no active fundraisers                                                                           # features/step_definitions/fundraiser_steps.rb:9
    When a donator goes to the curated streamer's shorter URL                                           # features/step_definitions/curated_streamer_steps.rb:94
    Then the donator should be informed that there are no active fundraisers                            # features/step_definitions/curated_streamer_steps.rb:102
    Given one active fundraiser                                                                         # features/step_definitions/fundraiser_steps.rb:1
    When a donator goes to the curated streamer's shorter URL                                           # features/step_definitions/curated_streamer_steps.rb:94
    Then the donator should be redirected to the curated streamer's page for the active fundraiser      # features/step_definitions/curated_streamer_steps.rb:98
    Given a second active fundraiser                                                                    # features/step_definitions/fundraiser_steps.rb:5
    When a donator goes to the curated streamer's shorter URL                                           # features/step_definitions/curated_streamer_steps.rb:94
    Then the donator should be offered links to the curated streamer's page for both active fundraisers # features/step_definitions/curated_streamer_steps.rb:106

1 scenario (1 passed)
```

Closes https://github.com/SmartCasual/jingle-jam/issues/168