### PR TITLE
Make email address required

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -5,6 +5,11 @@ class PaymentsController < ApplicationController
   def prep_checkout_session
     return unless request.headers["Accept"] == "application/json"
 
+    if params[:donator_email_address].blank? && current_donator&.email_address.blank?
+      error "You must provide an email address"
+      return
+    end
+
     set_current_donator
     update_current_donator
     save_current_donator

--- a/app/javascript/payments.js
+++ b/app/javascript/payments.js
@@ -41,14 +41,6 @@ export default class Payments {
           self._enableStripeButton();
 
           return stripe.redirectToCheckout({ sessionId: session.id });
-        })
-        .then(function(result) {
-          if (result.error) {
-            alert(result.error.message);
-          }
-        })
-        .catch(function(error) {
-          console.error('Error:', error);
         });
     });
   }
@@ -97,7 +89,16 @@ export default class Payments {
         "Accept": "application/json",
       },
       body: (new FormData(this.form)),
-    }).then((resp) => resp.json());
+    })
+    .then((resp) => resp.json())
+    .then((resp) => {
+      if (resp.errors) {
+        throw resp.errors;
+      } else {
+        return resp;
+      }
+    })
+    .catch((errors) => this._displayErrors(errors));
   }
 
   _disableStripeButton() {
@@ -106,5 +107,15 @@ export default class Payments {
 
   _enableStripeButton() {
     this.button.disabled = false;
+  }
+
+  _displayErrors(errors) {
+    const errorList = this.form.querySelector("ul.errors");
+    errorList.innerHTML = "";
+    errors.forEach(error => {
+      const errorItem = document.createElement("li");
+      errorItem.textContent = error;
+      errorList.appendChild(errorItem);
+    });
   }
 }

--- a/app/views/fundraisers/donations/_donation_form.html.erb
+++ b/app/views/fundraisers/donations/_donation_form.html.erb
@@ -20,6 +20,8 @@
 <h2><%= t("donations.form.header") %></h2>
 
 <%= form_for new_donation("25.00", fundraiser:), url: stripe_prep_checkout_path, html: { id: "donation-form", :'data-stripe-public-key' => ENV["STRIPE_PUBLIC_KEY"], :'data-test-mode' => Rails.env.test? } do |form| %>
+  <ul class="errors"></ul>
+
   <p>
     <%= form.label :amount_currency, t("donations.form.currency") %>
     <%= form.select :amount_currency, options_for_select(Currency.present_all, Currency::DEFAULT_CURRENCY.downcase) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
       action: "Card payment"
       amount: "Amount"
       currency: "Currency"
-      email_address: "Email address (optional)"
+      email_address: "Email address"
       header: "Make a donation"
       lock: "Lock slider"
       message: "Message (optional)"

--- a/features/donator_accounts/after_donation.feature
+++ b/features/donator_accounts/after_donation.feature
@@ -2,7 +2,7 @@ Feature: Donator accounts: after donation
 
 Scenario: Anonymous donator is offered more login options
   When a donator makes a donation without giving a name or an email address
-  Then they should be offered the ability to set up more ways to access their account
+  Then they should be told that an email address is required
 
 Scenario: Less anonymous donator is provided more login options less intrusively
   When a donator makes a donation giving an email address

--- a/features/donator_accounts/during_donation.feature
+++ b/features/donator_accounts/during_donation.feature
@@ -2,21 +2,11 @@ Feature: Donator accounts: During donation
 
 Scenario: Donator does not give a name or an email address
   When a donator makes a donation without giving a name or an email address
-  Then an anonymous account should have been made for the donator
-  And the donator should have been logged in
-  And the donator should see a token log-in link on the page
-  When the donator puts that link aside
-  And the donator logs out
-  Then the donator should be able to log back in with their link
+  Then they should be told that an email address is required
 
 Scenario: Donator gives a name but no email address
   When a donator makes a donation giving a name but no email address
-  Then an account should have been made for the donator with their name
-  And the donator should have been logged in
-  And the donator should see a token log-in link on the page
-  When the donator puts that link aside
-  And the donator logs out
-  Then the donator should be able to log back in with their link
+  Then they should be told that an email address is required
 
 Scenario: Donator gives an email address
   When a donator makes a donation giving an email address

--- a/features/step_definitions/bundle_steps.rb
+++ b/features/step_definitions/bundle_steps.rb
@@ -9,8 +9,12 @@ When("a donator makes a {amount} donation with the message {string}") do |amount
   make_donation(amount, message:, navigate: true)
 end
 
-When("a/the donator makes a/another {amount} donation") do |amount|
+When("a donator makes a {amount} donation") do |amount|
   make_donation(amount, navigate: true)
+end
+
+When("the donator makes another {amount} donation") do |amount|
+  make_donation(amount, navigate: true, email_address: false)
 end
 
 Then("a {amount} donation should be recorded with the message {string}") do |amount, message|
@@ -47,9 +51,20 @@ Then("the donation message should be cut off in the form") do
   expect(find_field("Message").value).to eq("a" * Donation::MAX_MESSAGE_LENGTH)
 end
 
-Then("the donation should (still )be recorded with the truncated message") do
+Then("the donation should be recorded with the truncated message") do
   make_donation(
     message: "a" * 1000,
+    navigate: true,
+    submit: true,
+  )
+
+  expect(Donation.last.message).to eq("a" * Donation::MAX_MESSAGE_LENGTH)
+end
+
+Then("the donation should still be recorded with the truncated message") do
+  make_donation(
+    message: "a" * 1000,
+    email_address: false,
     navigate: true,
     submit: true,
   )

--- a/features/step_definitions/donator_accounts/before_donaton_steps.rb
+++ b/features/step_definitions/donator_accounts/before_donaton_steps.rb
@@ -18,7 +18,7 @@ When("they immediately make a donation") do
   @amount = Money.new(10_00, "GBP")
 
   expect {
-    make_donation(@amount, navigate: true)
+    make_donation(@amount, navigate: true, email_address: false)
   }.to(change { @current_donator.reload.donations.count }.by(1))
 end
 

--- a/features/support/helpers/donation_test_helpers.rb
+++ b/features/support/helpers/donation_test_helpers.rb
@@ -5,7 +5,9 @@ module DonationTestHelpers
 
   def make_donation(amount = nil, stripe_options: {}, **options) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     options = {
-      email_address: nil,
+      email_address: "test@example.com",
+      expect_failure: false,
+      fundraiser: nil,
       message: nil,
       name: nil,
       navigate: false,
@@ -13,7 +15,6 @@ module DonationTestHelpers
       paypal: false,
       split: {},
       submit: true,
-      fundraiser: nil,
     }.merge(options)
 
     stripe_options = {
@@ -77,6 +78,8 @@ module DonationTestHelpers
           switch_to_window(main_window)
         end
 
+        return if options[:expect_failure]
+
         wait_for { Donation.count == (donation_count + 1) }
       else
         if stripe_options.delete(:stub)
@@ -84,6 +87,8 @@ module DonationTestHelpers
         end
 
         click_on "Card payment"
+        return if options[:expect_failure]
+
         wait_for { Donation.count == (donation_count + 1) }
 
         if TestData[:fake_payment_providers]

--- a/spec/requests/stripe_payments_controller_spec.rb
+++ b/spec/requests/stripe_payments_controller_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe StripePaymentsController, type: :request do
           human_amount: "25.00",
           amount_currency: currency,
         },
+        donator_email_address: "test@example.com",
       }
     end
 


### PR DESCRIPTION
It can't be removed from this form because while Stripe and Paypal both
require email addresses, we're only given these *after* payment has
been taken, whereas we create the donator record before then.

Closes https://github.com/SmartCasual/jingle-jam/issues/169